### PR TITLE
Refactor element names

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It is a collaboration between [ETH Zürich](https://ethz.ch) and [Nothing](https
     - ✅ When pressing `Up`/`Down` while the dropdown is closed, open it (and keep focus inside filter input).
     - ✅ When pressing `Up`/`Down` while the dropdown is open, move focus to last/first checkbox.
 - ✅ Keep `aria-expanded` in sync with the dropdown: set it to `true` when it is open, and to `false` when it is closed.
-- ✅ When clicking `.filter__close-options` button, close `fieldset.selected`, set focus to filter text field, and select all text (if there is any).
+- ✅ When clicking `.widget--toggle-options-button` button, close `fieldset.selected`, set focus to filter text field, and select all text (if there is any).
 - ✅ When typing a filter and the dropdown is closed, open it.
 - ✅ Hide the "Unselect all" button when there is no option selected.
 - ✅ When keyboard focus leaves the widget, close the dropdown.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It is a collaboration between [ETH Zürich](https://ethz.ch) and [Nothing](https
 - ✅ When a checkbox is focused and a character key is pressed, then move focus back to the filter input and append the typed character.
     - ✅ There are probably some "special keys" we need to implement, for example `Backspace` - any other that come to your mind?
         - ✅ `Delete` will remove the filter text
-- ✅ The first time a filter is entered, add `role="alert"` to `.available-hobbies__counter` (this will make screen readers announce it).
+- ✅ The first time a filter is entered, add `role="alert"` to `.widget--available-options-counter` (this will make screen readers announce it).
 - ✅ Set `hidden` to `fieldset.selected` when there is no option selected.
 - ✅ I added `3 selected` to "X options available", please update accordingly.
 - ✅ When `Esc` is pressed while the "X options selected" button is focused, then move focus back to the filter input (and select all text).

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ It is a collaboration between [ETH Zürich](https://ethz.ch) and [Nothing](https
     - Another option could be to only display "X options available" when expanding the list of options (instead of announcing it when focusing the filter text input), together with `role="alert"`.
 - The use of "advanced" CSS still seems to be dangerous: toggling some content inside `::after` when toggling a checkbox breaks the announcement of checked / not checked in Chrome! We better work around this with toggling an additional `<span>` or similar...
 - In JAWS + FF, focus mode seems to be on when focusing a checkbox (test by hitting a character => it will be appended to filter)! This is very surprising, as all other combos don't do this!
+- Chrome has a strange bug (regardless of NVDA or JAWS): the live region is sometimes not announced when the filter is focused (by keyboard) and then "a" or "d" is typed. Strange enough, when "f" is pressed, it seems to be announced all the time (it might have to do with the number of option displayed, or no options at all).
 
 ## Resources
 

--- a/multi.html
+++ b/multi.html
@@ -48,18 +48,18 @@
           <legend class="widget--options-legend">Available hobbies (3 selected)</legend>
 
           <ol class="widget--options-list">
-            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="soccer" checked data-visually-hidden><span> Soccer<span class="check"></span></span></label></li>
-            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="badminton" data-visually-hidden><span> Badminton<span class="check"></span></span></label></li>
-            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="movies" data-visually-hidden><span> Movies<span class="check"></span></span></label></li>
-            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="gardening" data-visually-hidden><span> Gardening<span class="check"></span></span></label></li>
-            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="kickboxing" data-visually-hidden><span> Kickboxing<span class="check"></span></span></label></li>
-            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="hiking" checked data-visually-hidden><span> Hiking<span class="check"></span></span></label></li>
-            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="dancing" data-visually-hidden><span> Dancing<span class="check"></span></span></label></li>
-            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="painting" data-visually-hidden><span> Painting<span class="check"></span></span></label></li>
-            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="cooking" checked data-visually-hidden><span> Cooking<span class="check"></span></span></label></li>
-            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="reading" data-visually-hidden><span> Reading<span class="check"></span></span></label></li>
-            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="sleeping" data-visually-hidden><span> Sleeping<span class="check"></span></span></label></li>
-            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="programming" data-visually-hidden><span> Programming<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="hobbies" value="soccer" checked data-visually-hidden><span> Soccer<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="hobbies" value="badminton" data-visually-hidden><span> Badminton<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="hobbies" value="movies" data-visually-hidden><span> Movies<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="hobbies" value="gardening" data-visually-hidden><span> Gardening<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="hobbies" value="kickboxing" data-visually-hidden><span> Kickboxing<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="hobbies" value="hiking" checked data-visually-hidden><span> Hiking<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="hobbies" value="dancing" data-visually-hidden><span> Dancing<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="hobbies" value="painting" data-visually-hidden><span> Painting<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="hobbies" value="cooking" checked data-visually-hidden><span> Cooking<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="hobbies" value="reading" data-visually-hidden><span> Reading<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="hobbies" value="sleeping" data-visually-hidden><span> Sleeping<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="hobbies" value="programming" data-visually-hidden><span> Programming<span class="check"></span></span></label></li>
           </ol>
         </fieldset>
       </div>

--- a/multi.html
+++ b/multi.html
@@ -34,7 +34,7 @@
           </p
         >--></label
         
-        ><button class="filter__reset-options" type="button">
+        ><button class="widget--unselect-all-button" type="button">
           <span class="filter__text" data-visually-hidden>3 options selected,</span>
           <img src="clear.svg" alt="unselect all" />
         </button

--- a/multi.html
+++ b/multi.html
@@ -48,18 +48,18 @@
           <legend class="widget--options-legend">Available hobbies (3 selected)</legend>
 
           <ol class="widget--options-list">
-            <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="soccer" checked data-visually-hidden><span> Soccer<span class="check"></span></span></label></li>
-            <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="badminton" data-visually-hidden><span> Badminton<span class="check"></span></span></label></li>
-            <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="movies" data-visually-hidden><span> Movies<span class="check"></span></span></label></li>
-            <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="gardening" data-visually-hidden><span> Gardening<span class="check"></span></span></label></li>
-            <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="kickboxing" data-visually-hidden><span> Kickboxing<span class="check"></span></span></label></li>
-            <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="hiking" checked data-visually-hidden><span> Hiking<span class="check"></span></span></label></li>
-            <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="dancing" data-visually-hidden><span> Dancing<span class="check"></span></span></label></li>
-            <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="painting" data-visually-hidden><span> Painting<span class="check"></span></span></label></li>
-            <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="cooking" checked data-visually-hidden><span> Cooking<span class="check"></span></span></label></li>
-            <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="reading" data-visually-hidden><span> Reading<span class="check"></span></span></label></li>
-            <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="sleeping" data-visually-hidden><span> Sleeping<span class="check"></span></span></label></li>
-            <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="programming" data-visually-hidden><span> Programming<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="soccer" checked data-visually-hidden><span> Soccer<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="badminton" data-visually-hidden><span> Badminton<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="movies" data-visually-hidden><span> Movies<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="gardening" data-visually-hidden><span> Gardening<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="kickboxing" data-visually-hidden><span> Kickboxing<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="hiking" checked data-visually-hidden><span> Hiking<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="dancing" data-visually-hidden><span> Dancing<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="painting" data-visually-hidden><span> Painting<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="cooking" checked data-visually-hidden><span> Cooking<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="reading" data-visually-hidden><span> Reading<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="sleeping" data-visually-hidden><span> Sleeping<span class="check"></span></span></label></li>
+            <li class="widget--options-list-item"><label><input type="checkbox" name="my_hobbies" value="programming" data-visually-hidden><span> Programming<span class="check"></span></span></label></li>
           </ol>
         </fieldset>
       </div>

--- a/multi.html
+++ b/multi.html
@@ -16,7 +16,7 @@
 
     <form>
     <div class="widget">
-      <div class="filter-and-options">
+      <div class="widget--filter-and-options">
         <label class="filter">
           <span class="filter__label" data-inline-block>My hobbies</span
           ><input class="filter__field" type="text" role="combobox" aria-expanded="false" type="text" autocomplete="off" placeholder="Filter term"

--- a/multi.html
+++ b/multi.html
@@ -35,7 +35,7 @@
         >--></label
         
         ><button class="widget--unselect-all-button" type="button">
-          <span class="filter__text" data-visually-hidden>3 options selected,</span>
+          <span class="widget--unselect-all-button-text" data-visually-hidden>3 options selected,</span>
           <img src="clear.svg" alt="unselect all" />
         </button
 

--- a/multi.html
+++ b/multi.html
@@ -15,8 +15,8 @@
     <hr>
 
     <form>
-    <div class="widget-container">
-      <div class="widget--filter-and-options">
+    <div class="widget--container">
+      <div class="widget--filter-and-options-container">
         <label class="filter">
           <span class="filter__label" data-inline-block>My hobbies</span
           ><input class="filter__field" type="text" role="combobox" aria-expanded="false" type="text" autocomplete="off" placeholder="Filter term"

--- a/multi.html
+++ b/multi.html
@@ -67,7 +67,7 @@
       <fieldset class="widget--selected-options-container">
         <legend class="widget--selected-options-legend" data-visually-hidden>Selected hobbies (3 in total)</legend>
 
-        <ol class="selected__list">
+        <ol class="widget--selected-options-list">
           <li>
             <button class="selected__button" type="button">
               Soccer

--- a/multi.html
+++ b/multi.html
@@ -15,7 +15,7 @@
     <hr>
 
     <form>
-    <div class="multi">
+    <div class="widget">
       <div class="filter-and-options">
         <label class="filter">
           <span class="filter__label" data-inline-block>My hobbies</span

--- a/multi.html
+++ b/multi.html
@@ -44,7 +44,7 @@
           <span data-visually-hidden>Open options</span><!-- TODO: Change to "Close options" when clicked! -->
         </button>
 
-        <fieldset class="widget--options-container" hidden>
+        <fieldset class="widget--available-options-container" hidden>
           <legend class="widget--options-legend">Available hobbies (3 selected)</legend>
 
           <ol class="widget--options-list">

--- a/multi.html
+++ b/multi.html
@@ -16,10 +16,10 @@
 
     <form>
     <div class="widget--container">
-      <label for="hobbies" class="filter__label" data-inline-block>My hobbies</label>
+      <label for="hobbies" class="widget--filter-label" data-inline-block>My hobbies</label>
       <div class="widget--filter-and-options-container" data-inline-block>
         <span class="widget--filter-container">
-          <input class="filter__field" id="hobbies" type="text" role="combobox" aria-expanded="false" type="text" autocomplete="off" placeholder="Filter term"
+          <input class="widget--filter-field" id="hobbies" type="text" role="combobox" aria-expanded="false" type="text" autocomplete="off" placeholder="Filter term"
           
           ><span data-visually-hidden>
             <!-- We might wanna show this info visually so that visual users also have the benefit of seeing it. General rule: try to show all relevant info to all users! If you need some specific help for ie. screen reader users only, you should think about whether you are doing something overly complex. We could place it inside `available-hobbies__legend`, or (if this produces too much noise when jumping inside the `fieldset`), just outside of it (and visually hide the `fieldset`). We could place also other important info there, ie. a spinner when elements are loaded through AJAX ("Loading options, please wait") or additional instructions, ie. "Type at least two characters to display options". -->

--- a/multi.html
+++ b/multi.html
@@ -16,8 +16,8 @@
 
     <form>
     <div class="widget--container">
-      <div class="widget--filter-and-options-container">
-        <label for="hobbies" class="filter__label">My hobbies</label>
+      <label for="hobbies" class="filter__label" data-inline-block>My hobbies</label>
+      <div class="widget--filter-and-options-container" data-inline-block>
         <span class="widget--filter-container">
           <input class="filter__field" id="hobbies" type="text" role="combobox" aria-expanded="false" type="text" autocomplete="off" placeholder="Filter term"
           

--- a/multi.html
+++ b/multi.html
@@ -65,7 +65,7 @@
       </div>
 
       <fieldset class="widget--selected-options-container">
-        <legend class="selected__legend" data-visually-hidden>Selected hobbies (3 in total)</legend>
+        <legend class="widget--selected-options-legend" data-visually-hidden>Selected hobbies (3 in total)</legend>
 
         <ol class="selected__list">
           <li>

--- a/multi.html
+++ b/multi.html
@@ -15,7 +15,7 @@
     <hr>
 
     <form>
-    <div class="widget">
+    <div class="widget-container">
       <div class="widget--filter-and-options">
         <label class="filter">
           <span class="filter__label" data-inline-block>My hobbies</span

--- a/multi.html
+++ b/multi.html
@@ -24,7 +24,7 @@
           ><span data-visually-hidden>
             <!-- We might wanna show this info visually so that visual users also have the benefit of seeing it. General rule: try to show all relevant info to all users! If you need some specific help for ie. screen reader users only, you should think about whether you are doing something overly complex. We could place it inside `available-hobbies__legend`, or (if this produces too much noise when jumping inside the `fieldset`), just outside of it (and visually hide the `fieldset`). We could place also other important info there, ie. a spinner when elements are loaded through AJAX ("Loading options, please wait") or additional instructions, ie. "Type at least two characters to display options". -->
             <span class="widget--available-options-counter">12 options available</span>,
-            <span class="available-hobbies__selected-counter">3 selected.</span>
+            <span class="widget--selected-options-counter">3 selected.</span>
           </span
 
           ><!--<p data-visually-hidden>

--- a/multi.html
+++ b/multi.html
@@ -64,7 +64,7 @@
         </fieldset>
       </div>
 
-      <fieldset class="selected">
+      <fieldset class="widget--selected-options-container">
         <legend class="selected__legend" data-visually-hidden>Selected hobbies (3 in total)</legend>
 
         <ol class="selected__list">

--- a/multi.html
+++ b/multi.html
@@ -39,7 +39,7 @@
           <img src="clear.svg" alt="unselect all" />
         </button
 
-        ><button class="filter__close-options" type="button">
+        ><button class="widget--toggle-options-button" type="button">
           <img src="close.svg" alt="" />
           <span data-visually-hidden>Open options</span><!-- TODO: Change to "Close options" when clicked! -->
         </button>

--- a/multi.html
+++ b/multi.html
@@ -69,19 +69,19 @@
 
         <ol class="widget--selected-options-list">
           <li>
-            <button class="selected__button" type="button">
+            <button class="widget--selected-options-button" type="button">
               Soccer
               <img src="clear.svg" alt="unselect" />
             </button>
           </li>
           <li>
-            <button class="selected__button"type="button">
+            <button class="widget--selected-options-button" type="button">
               Hiking
               <img src="clear.svg" alt="unselect" />
             </button>
           </li>
           <li>
-            <button class="selected__button"type="button">
+            <button class="widget--selected-options-button" type="button">
               Cooking
               <img src="clear.svg" alt="unselect" />
             </button>

--- a/multi.html
+++ b/multi.html
@@ -14,7 +14,8 @@
 
     <hr>
 
-    <form class="multi">
+    <form>
+    <div class="multi">
       <div class="filter-and-options">
         <label class="filter">
           <span class="filter__label" data-inline-block>My hobbies</span
@@ -87,6 +88,7 @@
           </li>
         </ol>
       </fieldset>
+    </div>
     </form>
 
     <hr>

--- a/multi.html
+++ b/multi.html
@@ -17,9 +17,9 @@
     <form>
     <div class="widget--container">
       <div class="widget--filter-and-options-container">
-        <label class="filter">
-          <span class="filter__label" data-inline-block>My hobbies</span
-          ><input class="filter__field" type="text" role="combobox" aria-expanded="false" type="text" autocomplete="off" placeholder="Filter term"
+        <label for="hobbies" class="filter__label">My hobbies</label>
+        <span class="widget--filter-container">
+          <input class="filter__field" id="hobbies" type="text" role="combobox" aria-expanded="false" type="text" autocomplete="off" placeholder="Filter term"
           
           ><span data-visually-hidden>
             <!-- We might wanna show this info visually so that visual users also have the benefit of seeing it. General rule: try to show all relevant info to all users! If you need some specific help for ie. screen reader users only, you should think about whether you are doing something overly complex. We could place it inside `available-hobbies__legend`, or (if this produces too much noise when jumping inside the `fieldset`), just outside of it (and visually hide the `fieldset`). We could place also other important info there, ie. a spinner when elements are loaded through AJAX ("Loading options, please wait") or additional instructions, ie. "Type at least two characters to display options". -->

--- a/multi.html
+++ b/multi.html
@@ -44,7 +44,7 @@
           <span data-visually-hidden>Open options</span><!-- TODO: Change to "Close options" when clicked! -->
         </button>
 
-        <fieldset class="options" hidden>
+        <fieldset class="widget--options-container" hidden>
           <legend class="available-hobbies__legend">Available hobbies (3 selected)</legend>
 
           <ol class="options__list">

--- a/multi.html
+++ b/multi.html
@@ -22,7 +22,7 @@
           <input class="widget--filter-field" id="hobbies" type="text" role="combobox" aria-expanded="false" type="text" autocomplete="off" placeholder="Filter term"
           
           ><span data-visually-hidden>
-            <!-- We might wanna show this info visually so that visual users also have the benefit of seeing it. General rule: try to show all relevant info to all users! If you need some specific help for ie. screen reader users only, you should think about whether you are doing something overly complex. We could place it inside `available-hobbies__legend`, or (if this produces too much noise when jumping inside the `fieldset`), just outside of it (and visually hide the `fieldset`). We could place also other important info there, ie. a spinner when elements are loaded through AJAX ("Loading options, please wait") or additional instructions, ie. "Type at least two characters to display options". -->
+            <!-- We might wanna show this info visually so that visual users also have the benefit of seeing it. General rule: try to show all relevant info to all users! If you need some specific help for ie. screen reader users only, you should think about whether you are doing something overly complex. We could place it inside `widget--options-legend`, or (if this produces too much noise when jumping inside the `fieldset`), just outside of it (and visually hide the `fieldset`). We could place also other important info there, ie. a spinner when elements are loaded through AJAX ("Loading options, please wait") or additional instructions, ie. "Type at least two characters to display options". -->
             <span class="widget--available-options-counter">12 options available</span>,
             <span class="widget--selected-options-counter">3 selected.</span>
           </span
@@ -45,7 +45,7 @@
         </button>
 
         <fieldset class="widget--options-container" hidden>
-          <legend class="available-hobbies__legend">Available hobbies (3 selected)</legend>
+          <legend class="widget--options-legend">Available hobbies (3 selected)</legend>
 
           <ol class="options__list">
             <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="soccer" checked data-visually-hidden><span> Soccer<span class="check"></span></span></label></li>

--- a/multi.html
+++ b/multi.html
@@ -47,7 +47,7 @@
         <fieldset class="widget--options-container" hidden>
           <legend class="widget--options-legend">Available hobbies (3 selected)</legend>
 
-          <ol class="options__list">
+          <ol class="widget--options-list">
             <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="soccer" checked data-visually-hidden><span> Soccer<span class="check"></span></span></label></li>
             <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="badminton" data-visually-hidden><span> Badminton<span class="check"></span></span></label></li>
             <li class="hobby-item"><label><input type="checkbox" name="my_hobbies" value="movies" data-visually-hidden><span> Movies<span class="check"></span></span></label></li>

--- a/multi.html
+++ b/multi.html
@@ -23,7 +23,7 @@
           
           ><span data-visually-hidden>
             <!-- We might wanna show this info visually so that visual users also have the benefit of seeing it. General rule: try to show all relevant info to all users! If you need some specific help for ie. screen reader users only, you should think about whether you are doing something overly complex. We could place it inside `available-hobbies__legend`, or (if this produces too much noise when jumping inside the `fieldset`), just outside of it (and visually hide the `fieldset`). We could place also other important info there, ie. a spinner when elements are loaded through AJAX ("Loading options, please wait") or additional instructions, ie. "Type at least two characters to display options". -->
-            <span class="available-hobbies__counter">12 options available</span>,
+            <span class="widget--available-options-counter">12 options available</span>,
             <span class="available-hobbies__selected-counter">3 selected.</span>
           </span
 

--- a/multi.html
+++ b/multi.html
@@ -19,7 +19,7 @@
       <label for="hobbies" class="widget--filter-label" data-inline-block>My hobbies</label>
       <div class="widget--filter-and-options-container" data-inline-block>
         <span class="widget--filter-container">
-          <input class="widget--filter-field" id="hobbies" type="text" role="combobox" aria-expanded="false" type="text" autocomplete="off" placeholder="Filter term"
+          <input class="widget--filter-input" id="hobbies" type="text" role="combobox" aria-expanded="false" type="text" autocomplete="off" placeholder="Filter term"
           
           ><span data-visually-hidden>
             <!-- We might wanna show this info visually so that visual users also have the benefit of seeing it. General rule: try to show all relevant info to all users! If you need some specific help for ie. screen reader users only, you should think about whether you are doing something overly complex. We could place it inside `widget--options-legend`, or (if this produces too much noise when jumping inside the `fieldset`), just outside of it (and visually hide the `fieldset`). We could place also other important info there, ie. a spinner when elements are loaded through AJAX ("Loading options, please wait") or additional instructions, ie. "Type at least two characters to display options". -->

--- a/scripts.js
+++ b/scripts.js
@@ -2,7 +2,7 @@
 
 const elems = {};
 
-elems.widget = document.querySelector(".widget");
+elems.widgetContainer = document.querySelector(".widget-container");
 elems.filterAndOptionsContainer = document.querySelector(".widget--filter-and-options");
 elems.filter = document.querySelector(".filter");
 elems.options = document.querySelector(".options");
@@ -91,7 +91,7 @@ function onFilterFieldChangeOnce() {
   elems.filterField.removeEventListener("input", onFilterFieldChangeOnce);
 }
 
-elems.widget.addEventListener("keyup", onKeyup);
+elems.widgetContainer.addEventListener("keyup", onKeyup);
 
 function onKeyup(event) {
   if (event.key === "ArrowDown" || event.key === "ArrowUp") {
@@ -177,7 +177,7 @@ function onCheckboxChange(event) {
   else elems.filterResetOptions.removeAttribute("hidden");
 
   if (event?.target) {
-    elems.widget.dispatchEvent(
+    elems.widgetContainer.dispatchEvent(
       new CustomEvent(`option-${event.target.checked ? "" : "un"}selected`, {
         detail: event.target.value,
       })
@@ -337,14 +337,14 @@ function isTargetElementInDirectTree({ event, targetElement }) {
   }
 }
 
-elems.widget.addEventListener(`option-selected`, (event) => {
+elems.widgetContainer.addEventListener(`option-selected`, (event) => {
   elems.eventLogger.innerText =
     event.detail === `all checkboxes`
       ? `Event: All checkboxes were unselected`
       : `Event: Option ${event.detail} was ${event.type.split("-")[1]}`;
 });
 
-elems.widget.addEventListener(`option-unselected`, (event) => {
+elems.widgetContainer.addEventListener(`option-unselected`, (event) => {
   elems.eventLogger.innerText =
     event.detail === `all checkboxes`
       ? `Event: All checkboxes were unselected`

--- a/scripts.js
+++ b/scripts.js
@@ -9,6 +9,9 @@ elems.filterField = document.querySelector(".widget--filter-field");
 elems.availableOptionsCounter = document.querySelector(
   ".widget--available-options-counter"
 );
+elems.selectedOptionsCounter = document.querySelector(
+  ".widget--selected-options-counter"
+);
 elems.options = document.querySelector(".options");
 elems.hobbyItems = document.querySelectorAll(".hobby-item");
 elems.availableHobbiesLegend = document.querySelector(
@@ -21,9 +24,6 @@ elems.filterCloseOptions = document.querySelector(".filter__close-options");
 elems.selected = document.querySelector(".selected");
 elems.selectedList = document.querySelector(".selected__list");
 elems.selectedLegend = document.querySelector(".selected__legend");
-elems.availableHobbiesSelectedCounter = document.querySelector(
-  ".available-hobbies__selected-counter"
-);
 elems.eventLogger = document.querySelector(".event-logger");
 
 elems.arrowSelectableElems = [elems.filterField, ...elems.hobbyItems];
@@ -170,7 +170,7 @@ function onCheckboxChange(event) {
   elems.filterText.innerHTML = composeFilteringButtonText(checkedItemTexts);
   updateSelectedList(checkedItemTexts);
   elems.selectedLegend.innerText = `Selected hobbies (${checkedItemTexts.length} in total)`;
-  elems.availableHobbiesSelectedCounter.innerText = `${checkedItems.length} selected.`;
+  elems.selectedOptionsCounter.innerText = `${checkedItems.length} selected.`;
 
   if (checkedItems.length === 0)
     elems.filterResetOptions.setAttribute("hidden", "");

--- a/scripts.js
+++ b/scripts.js
@@ -23,7 +23,7 @@ elems.optionsListItems = document.querySelectorAll(".widget--options-list-item")
 elems.optionsListInputs = document.querySelectorAll(".widget--options-list-item input");
 elems.selectedOptionsContainer = document.querySelector(".widget--selected-options-container");
 elems.selectedOptionsLegend = document.querySelector(".widget--selected-options-legend");
-elems.selectedList = document.querySelector(".selected__list");
+elems.selectedOptionsList = document.querySelector(".widget--selected-options-list");
 elems.eventLogger = document.querySelector(".event-logger");
 
 elems.arrowSelectableElems = [elems.filterInput, ...elems.optionsListItems];
@@ -206,7 +206,7 @@ function updateSelectedList(checkedItemTexts) {
   </button></li>`
     )
     .join("");
-  elems.selectedList.innerHTML = allEntries;
+  elems.selectedOptionsList.innerHTML = allEntries;
   elems.selectedOptionsCounter.hidden = checkedItemTexts.length === 0;
 }
 
@@ -237,7 +237,7 @@ function resetCheckboxes() {
   elems.filterInput.select();
 }
 
-elems.selectedList.addEventListener("click", onSelectedButtonClick);
+elems.selectedOptionsList.addEventListener("click", onSelectedButtonClick);
 
 function onSelectedButtonClick(event) {
   const { target } = event;

--- a/scripts.js
+++ b/scripts.js
@@ -13,13 +13,13 @@ elems.selectedOptionsCounter = document.querySelector(
   ".widget--selected-options-counter"
 );
 elems.unselectAllButton = document.querySelector(".widget--unselect-all-button");
+elems.unselectAllbuttonText = document.querySelector(".widget--unselect-all-button-text");
 elems.options = document.querySelector(".options");
 elems.hobbyItems = document.querySelectorAll(".hobby-item");
 elems.availableHobbiesLegend = document.querySelector(
   ".available-hobbies__legend"
 );
 elems.hobbyItemInputs = document.querySelectorAll(".hobby-item input");
-elems.filterText = document.querySelector(".filter__text");
 elems.filterCloseOptions = document.querySelector(".filter__close-options");
 elems.selected = document.querySelector(".selected");
 elems.selectedList = document.querySelector(".selected__list");
@@ -167,7 +167,7 @@ function onCheckboxChange(event) {
   );
 
   elems.availableHobbiesLegend.innerHTML = `Available hobbies (${checkedItems.length} selected)`;
-  elems.filterText.innerHTML = composeFilteringButtonText(checkedItemTexts);
+  elems.unselectAllbuttonText.innerHTML = composeFilteringButtonText(checkedItemTexts);
   updateSelectedList(checkedItemTexts);
   elems.selectedLegend.innerText = `Selected hobbies (${checkedItemTexts.length} in total)`;
   elems.selectedOptionsCounter.innerText = `${checkedItems.length} selected.`;

--- a/scripts.js
+++ b/scripts.js
@@ -21,7 +21,7 @@ elems.optionsLegend = document.querySelector(
 );
 elems.optionsListItems = document.querySelectorAll(".widget--options-list-item");
 elems.optionsListInputs = document.querySelectorAll(".widget--options-list-item input");
-elems.selected = document.querySelector(".selected");
+elems.selectedOptionsContainer = document.querySelector(".widget--selected-options-container");
 elems.selectedList = document.querySelector(".selected__list");
 elems.selectedLegend = document.querySelector(".selected__legend");
 elems.eventLogger = document.querySelector(".event-logger");
@@ -207,7 +207,7 @@ function updateSelectedList(checkedItemTexts) {
     )
     .join("");
   elems.selectedList.innerHTML = allEntries;
-  elems.selected.hidden = checkedItemTexts.length === 0;
+  elems.selectedOptionsCounter.hidden = checkedItemTexts.length === 0;
 }
 
 elems.optionsListInputs.forEach((checkbox) =>

--- a/scripts.js
+++ b/scripts.js
@@ -16,10 +16,10 @@ elems.unselectAllButton = document.querySelector(".widget--unselect-all-button")
 elems.unselectAllButtonText = document.querySelector(".widget--unselect-all-button-text");
 elems.toggleOptionsbutton = document.querySelector(".widget--toggle-options-button");
 elems.optionsContainer = document.querySelector(".widget--options-container");
-elems.hobbyItems = document.querySelectorAll(".hobby-item");
-elems.availableHobbiesLegend = document.querySelector(
-  ".available-hobbies__legend"
+elems.optionsLegend = document.querySelector(
+  ".widget--options-legend"
 );
+elems.hobbyItems = document.querySelectorAll(".hobby-item");
 elems.hobbyItemInputs = document.querySelectorAll(".hobby-item input");
 elems.selected = document.querySelector(".selected");
 elems.selectedList = document.querySelector(".selected__list");
@@ -166,7 +166,7 @@ function onCheckboxChange(event) {
     item.querySelector("label").innerText.trim()
   );
 
-  elems.availableHobbiesLegend.innerHTML = `Available hobbies (${checkedItems.length} selected)`;
+  elems.optionsLegend.innerHTML = `Available hobbies (${checkedItems.length} selected)`;
   elems.unselectAllButtonText.innerHTML = composeFilteringButtonText(checkedItemTexts);
   updateSelectedList(checkedItemTexts);
   elems.selectedLegend.innerText = `Selected hobbies (${checkedItemTexts.length} in total)`;

--- a/scripts.js
+++ b/scripts.js
@@ -14,7 +14,7 @@ elems.selectedOptionsCounter = document.querySelector(
 );
 elems.unselectAllButton = document.querySelector(".widget--unselect-all-button");
 elems.unselectAllButtonText = document.querySelector(".widget--unselect-all-button-text");
-elems.toggleOptionsbutton = document.querySelector(".widget--toggle-options-button");
+elems.toggleOptionsButton = document.querySelector(".widget--toggle-options-button");
 elems.availableOptionsContainer = document.querySelector(".widget--available-options-container");
 elems.optionsLegend = document.querySelector(
   ".widget--options-legend"
@@ -27,22 +27,22 @@ elems.selectedOptionsList = document.querySelector(".widget--selected-options-li
 elems.eventLogger = document.querySelector(".event-logger");
 
 elems.arrowSelectableElems = [elems.filterInput, ...elems.optionsListItems];
-elems.filterInput.addEventListener("input", onFilterFieldChange);
-elems.filterInput.addEventListener("input", onFilterFieldChangeOnce);
-elems.filterInput.addEventListener("keyup", onFilterFieldKeyup);
-elems.filterInput.addEventListener("click", onFilterFieldClick);
+elems.filterInput.addEventListener("input", onFilterInputChange);
+elems.filterInput.addEventListener("input", onFilterInputChangeOnce);
+elems.filterInput.addEventListener("keyup", onFilterInputKeyup);
+elems.filterInput.addEventListener("click", onFilterInputClick);
 
-function onFilterFieldClick(event) {
-  if (filterFieldHasFocus) closeOptions();
+function onFilterInputClick(event) {
+  if (FilterInputHasFocus) closeOptions();
   else openOptions();
 }
 
-function onFilterFieldKeyup(event) {
+function onFilterInputKeyup(event) {
   if (event.key === "Escape") closeOptions();
 }
 
 let filterTerm = "";
-let filterFieldHasFocus;
+let FilterInputHasFocus;
 let lastSelected = 0;
 let numberOfElems = elems.arrowSelectableElems.length;
 const textInputRegexp = /^(([a-zA-Z])|(Backspace)|(Delete))$/;
@@ -51,9 +51,9 @@ const events = {
   optionUnselected: new CustomEvent("option-unselected"),
 };
 
-elems.toggleOptionsbutton.addEventListener("click", onFilterCloseOptionsClicked);
+elems.toggleOptionsButton.addEventListener("click", onToggleOptionsButtonClicked);
 
-function onFilterCloseOptionsClicked() {
+function onToggleOptionsButtonClicked() {
   isOptionsOpen() ? closeOptions() : openOptions();
   elems.filterInput.select();
 }
@@ -70,7 +70,7 @@ for (let elem of [elems.filterContainer, elems.availableOptionsContainer]) {
   });
 }
 
-function onFilterFieldChange(event) {
+function onFilterInputChange(event) {
   filterTerm = event.target.value.toLowerCase();
 
   let numberOfShownHobbies = 0;
@@ -86,9 +86,9 @@ function onFilterFieldChange(event) {
   openOptions();
 }
 
-function onFilterFieldChangeOnce() {
+function onFilterInputChangeOnce() {
   elems.availableOptionsCounter.setAttribute("role", "alert");
-  elems.filterInput.removeEventListener("input", onFilterFieldChangeOnce);
+  elems.filterInput.removeEventListener("input", onFilterInputChangeOnce);
 }
 
 elems.widgetContainer.addEventListener("keyup", onKeyup);
@@ -116,19 +116,19 @@ function onKeyup(event) {
 
   {
     const { target } = event;
-    const { filterField } = elems;
+    const { FilterInput } = elems;
 
     if (event.key.match(textInputRegexp)) {
-      if (target !== filterField) {
+      if (target !== FilterInput) {
         if (event.key.match(/^Backspace$/)) {
-          filterField.value = filterField.value.slice(0, -1);
+          FilterInput.value = FilterInput.value.slice(0, -1);
         } else if (event.key.match(/^Delete$/)) {
-          filterField.value = "";
+          FilterInput.value = "";
         } else {
-          filterField.value += event.key;
+          FilterInput.value += event.key;
         }
-        filterField.focus();
-        filterField.dispatchEvent(new Event("input"));
+        FilterInput.focus();
+        FilterInput.dispatchEvent(new Event("input"));
       }
     }
   }

--- a/scripts.js
+++ b/scripts.js
@@ -202,7 +202,7 @@ function updateSelectedList(checkedItemTexts) {
     .map(
       (
         text
-      ) => `<li><button class="selected__button" type="button">${text} <img src="clear.svg" alt="unselect">
+      ) => `<li><button class="widget--selected-options-button" type="button">${text} <img src="clear.svg" alt="unselect">
   </button></li>`
     )
     .join("");
@@ -241,13 +241,13 @@ elems.selectedOptionsList.addEventListener("click", onSelectedButtonClick);
 
 function onSelectedButtonClick(event) {
   const { target } = event;
-  const button = target.classList.contains("selected__button")
+  const button = target.classList.contains("widget--selected-options-button")
     ? target
-    : target.parentNode.classList.contains("selected__button")
+    : target.parentNode.classList.contains("widget--selected-options-button")
     ? target.parentNode
     : undefined;
 
-  if (button?.classList.contains("selected__button")) {
+  if (button?.classList.contains("widget--selected-options-button")) {
     const optionText = button.innerText.trim().toLowerCase();
     const hobbyItem = Array.from(document.querySelectorAll(".widget--options-list-item")).find(
       (item) => item.querySelector("input").value === optionText
@@ -255,7 +255,7 @@ function onSelectedButtonClick(event) {
     hobbyItem.querySelector("input").checked = false;
 
     const selectedButtons = Array.from(
-      document.querySelectorAll(".selected__button")
+      document.querySelectorAll(".widget--selected-options-button")
     );
     const clickedIndex = selectedButtons.reduce((acc, curr, index) => {
       if (curr.innerText.trim() === optionText) return index;
@@ -273,7 +273,7 @@ function onSelectedButtonClick(event) {
           : clickedIndex - 1;
       if (nextIndex >= 0) {
         setTimeout(() => {
-          Array.from(document.querySelectorAll(".selected__button"))[
+          Array.from(document.querySelectorAll(".widget--selected-options-button"))[
             nextIndex
           ].focus();
         });

--- a/scripts.js
+++ b/scripts.js
@@ -6,6 +6,9 @@ elems.widgetContainer = document.querySelector(".widget--container");
 elems.filterAndOptionsContainer = document.querySelector(".widget--filter-and-options-container");
 elems.filterContainer = document.querySelector(".widget--filter-container");
 elems.filterField = document.querySelector(".widget--filter-field");
+elems.availableOptionsCounter = document.querySelector(
+  ".widget--available-options-counter"
+);
 elems.options = document.querySelector(".options");
 elems.hobbyItems = document.querySelectorAll(".hobby-item");
 elems.availableHobbiesLegend = document.querySelector(
@@ -18,9 +21,6 @@ elems.filterCloseOptions = document.querySelector(".filter__close-options");
 elems.selected = document.querySelector(".selected");
 elems.selectedList = document.querySelector(".selected__list");
 elems.selectedLegend = document.querySelector(".selected__legend");
-elems.availableHobbiesCounter = document.querySelector(
-  ".available-hobbies__counter"
-);
 elems.availableHobbiesSelectedCounter = document.querySelector(
   ".available-hobbies__selected-counter"
 );
@@ -79,7 +79,7 @@ function onFilterFieldChange(event) {
     if (!hobbyItem.hidden) numberOfShownHobbies += 1;
   }
 
-  elems.availableHobbiesCounter.innerText = `${numberOfShownHobbies} option${
+  elems.availableOptionsCounter.innerText = `${numberOfShownHobbies} option${
     numberOfShownHobbies === 1 ? "" : "s"
   } available for ${filterTerm}`;
 
@@ -87,7 +87,7 @@ function onFilterFieldChange(event) {
 }
 
 function onFilterFieldChangeOnce() {
-  elems.availableHobbiesCounter.setAttribute("role", "alert");
+  elems.availableOptionsCounter.setAttribute("role", "alert");
   elems.filterField.removeEventListener("input", onFilterFieldChangeOnce);
 }
 

--- a/scripts.js
+++ b/scripts.js
@@ -34,7 +34,7 @@ elems.filterInput.addEventListener("click", onFilterInputClick);
 
 function onFilterInputClick(event) {
   if (FilterInputHasFocus) closeOptions();
-  else openOptions();
+  else showOptionsContainer();
 }
 
 function onFilterInputKeyup(event) {
@@ -54,7 +54,7 @@ const events = {
 elems.toggleOptionsButton.addEventListener("click", onToggleOptionsButtonClicked);
 
 function onToggleOptionsButtonClicked() {
-  isOptionsOpen() ? closeOptions() : openOptions();
+  isOptionsOpen() ? closeOptions() : showOptionsContainer();
   elems.filterInput.select();
 }
 
@@ -83,7 +83,7 @@ function onFilterInputChange(event) {
     numberOfShownHobbies === 1 ? "" : "s"
   } available for ${filterTerm}`;
 
-  openOptions();
+  showOptionsContainer();
 }
 
 function onFilterInputChangeOnce() {
@@ -110,7 +110,7 @@ function onKeyup(event) {
         }
       }
     } else {
-      openOptions();
+      showOptionsContainer();
     }
   }
 
@@ -286,7 +286,7 @@ function onSelectedButtonClick(event) {
   }
 }
 
-function openOptions() {
+function showOptionsContainer() {
   elems.availableOptionsContainer.removeAttribute("hidden");
   elems.filterInput.setAttribute("aria-expanded", true);
   elems.filterAndOptionsContainer.classList.add("open");

--- a/scripts.js
+++ b/scripts.js
@@ -15,7 +15,7 @@ elems.selectedOptionsCounter = document.querySelector(
 elems.unselectAllButton = document.querySelector(".widget--unselect-all-button");
 elems.unselectAllButtonText = document.querySelector(".widget--unselect-all-button-text");
 elems.toggleOptionsbutton = document.querySelector(".widget--toggle-options-button");
-elems.optionsContainer = document.querySelector(".widget--options-container");
+elems.availableOptionsContainer = document.querySelector(".widget--available-options-container");
 elems.optionsLegend = document.querySelector(
   ".widget--options-legend"
 );
@@ -58,7 +58,7 @@ function onFilterCloseOptionsClicked() {
   elems.filterInput.select();
 }
 
-for (let elem of [elems.filterContainer, elems.optionsContainer]) {
+for (let elem of [elems.filterContainer, elems.availableOptionsContainer]) {
   elem.addEventListener("keyup", function (event) {
     if (event.key === "PageDown" || event.key === "PageUp") {
       const shownElems = [...elems.optionsListItems].filter((elem) => !elem.hidden);
@@ -287,19 +287,19 @@ function onSelectedButtonClick(event) {
 }
 
 function openOptions() {
-  elems.optionsContainer.removeAttribute("hidden");
+  elems.availableOptionsContainer.removeAttribute("hidden");
   elems.filterInput.setAttribute("aria-expanded", true);
   elems.filterAndOptionsContainer.classList.add("open");
 }
 
 function closeOptions() {
-  elems.optionsContainer.setAttribute("hidden", "");
+  elems.availableOptionsContainer.setAttribute("hidden", "");
   elems.filterInput.setAttribute("aria-expanded", false);
   elems.filterAndOptionsContainer.classList.remove("open");
 }
 
 function isOptionsOpen() {
-  return elems.optionsContainer.getAttribute("hidden") === null;
+  return elems.availableOptionsContainer.getAttribute("hidden") === null;
 }
 
 document.body.addEventListener("click", (event) => {

--- a/scripts.js
+++ b/scripts.js
@@ -5,7 +5,7 @@ const elems = {};
 elems.widgetContainer = document.querySelector(".widget--container");
 elems.filterAndOptionsContainer = document.querySelector(".widget--filter-and-options-container");
 elems.filterContainer = document.querySelector(".widget--filter-container");
-elems.filterField = document.querySelector(".widget--filter-field");
+elems.filterInput = document.querySelector(".widget--filter-input");
 elems.availableOptionsCounter = document.querySelector(
   ".widget--available-options-counter"
 );
@@ -26,11 +26,11 @@ elems.selectedOptionsLegend = document.querySelector(".widget--selected-options-
 elems.selectedList = document.querySelector(".selected__list");
 elems.eventLogger = document.querySelector(".event-logger");
 
-elems.arrowSelectableElems = [elems.filterField, ...elems.optionsListItems];
-elems.filterField.addEventListener("input", onFilterFieldChange);
-elems.filterField.addEventListener("input", onFilterFieldChangeOnce);
-elems.filterField.addEventListener("keyup", onFilterFieldKeyup);
-elems.filterField.addEventListener("click", onFilterFieldClick);
+elems.arrowSelectableElems = [elems.filterInput, ...elems.optionsListItems];
+elems.filterInput.addEventListener("input", onFilterFieldChange);
+elems.filterInput.addEventListener("input", onFilterFieldChangeOnce);
+elems.filterInput.addEventListener("keyup", onFilterFieldKeyup);
+elems.filterInput.addEventListener("click", onFilterFieldClick);
 
 function onFilterFieldClick(event) {
   if (filterFieldHasFocus) closeOptions();
@@ -55,7 +55,7 @@ elems.toggleOptionsbutton.addEventListener("click", onFilterCloseOptionsClicked)
 
 function onFilterCloseOptionsClicked() {
   isOptionsOpen() ? closeOptions() : openOptions();
-  elems.filterField.select();
+  elems.filterInput.select();
 }
 
 for (let elem of [elems.filterContainer, elems.optionsContainer]) {
@@ -88,7 +88,7 @@ function onFilterFieldChange(event) {
 
 function onFilterFieldChangeOnce() {
   elems.availableOptionsCounter.setAttribute("role", "alert");
-  elems.filterField.removeEventListener("input", onFilterFieldChangeOnce);
+  elems.filterInput.removeEventListener("input", onFilterFieldChangeOnce);
 }
 
 elems.widgetContainer.addEventListener("keyup", onKeyup);
@@ -101,7 +101,7 @@ function onKeyup(event) {
         let j = modulo(direction * (i + 1) + lastSelected, numberOfElems);
         let currentElem = elems.arrowSelectableElems[j];
         if (!currentElem.hidden) {
-          if (currentElem === elems.filterField) {
+          if (currentElem === elems.filterInput) {
             currentElem.select();
           } else {
             currentElem.querySelector("input").focus();
@@ -134,7 +134,7 @@ function onKeyup(event) {
   }
 }
 
-elems.filterField.addEventListener("focus", () => {
+elems.filterInput.addEventListener("focus", () => {
   lastSelected = 0;
 });
 
@@ -226,7 +226,7 @@ elems.unselectAllButton.addEventListener("click", resetCheckboxes);
 elems.unselectAllButton.addEventListener("keyup", onFilterButtonKeyup);
 
 function onFilterButtonKeyup(event) {
-  if (event.key === "Escape") elems.filterField.select();
+  if (event.key === "Escape") elems.filterInput.select();
 }
 
 function resetCheckboxes() {
@@ -234,7 +234,7 @@ function resetCheckboxes() {
     checkbox.checked = false;
   }
   onCheckboxChange({ target: { checked: false, value: "all checkboxes" } });
-  elems.filterField.select();
+  elems.filterInput.select();
 }
 
 elems.selectedList.addEventListener("click", onSelectedButtonClick);
@@ -277,7 +277,7 @@ function onSelectedButtonClick(event) {
             nextIndex
           ].focus();
         });
-      } else elems.filterField.select();
+      } else elems.filterInput.select();
     }
 
     onCheckboxChange({ target: { checked: false, value: optionText } });
@@ -288,13 +288,13 @@ function onSelectedButtonClick(event) {
 
 function openOptions() {
   elems.optionsContainer.removeAttribute("hidden");
-  elems.filterField.setAttribute("aria-expanded", true);
+  elems.filterInput.setAttribute("aria-expanded", true);
   elems.filterAndOptionsContainer.classList.add("open");
 }
 
 function closeOptions() {
   elems.optionsContainer.setAttribute("hidden", "");
-  elems.filterField.setAttribute("aria-expanded", false);
+  elems.filterInput.setAttribute("aria-expanded", false);
   elems.filterAndOptionsContainer.classList.remove("open");
 }
 

--- a/scripts.js
+++ b/scripts.js
@@ -73,14 +73,14 @@ for (let elem of [elems.filterContainer, elems.availableOptionsContainer]) {
 function onFilterInputChange(event) {
   filterTerm = event.target.value.toLowerCase();
 
-  let numberOfShownHobbies = 0;
+  let numberOfShownOptions = 0;
   for (let optionItem of elems.optionsListItems) {
     optionItem.hidden = !optionItem.innerText.toLowerCase().includes(filterTerm);
-    if (!optionItem.hidden) numberOfShownHobbies += 1;
+    if (!optionItem.hidden) numberOfShownOptions += 1;
   }
 
-  elems.availableOptionsCounter.innerText = `${numberOfShownHobbies} option${
-    numberOfShownHobbies === 1 ? "" : "s"
+  elems.availableOptionsCounter.innerText = `${numberOfShownOptions} option${
+    numberOfShownOptions === 1 ? "" : "s"
   } available for ${filterTerm}`;
 
   showOptionsContainer();

--- a/scripts.js
+++ b/scripts.js
@@ -5,13 +5,13 @@ const elems = {};
 elems.widgetContainer = document.querySelector(".widget--container");
 elems.filterAndOptionsContainer = document.querySelector(".widget--filter-and-options-container");
 elems.filterContainer = document.querySelector(".widget--filter-container");
+elems.filterField = document.querySelector(".widget--filter-field");
 elems.options = document.querySelector(".options");
 elems.hobbyItems = document.querySelectorAll(".hobby-item");
 elems.availableHobbiesLegend = document.querySelector(
   ".available-hobbies__legend"
 );
 elems.hobbyItemInputs = document.querySelectorAll(".hobby-item input");
-elems.filterField = document.querySelector(".filter__field");
 elems.filterResetOptions = document.querySelector(".filter__reset-options");
 elems.filterText = document.querySelector(".filter__text");
 elems.filterCloseOptions = document.querySelector(".filter__close-options");

--- a/scripts.js
+++ b/scripts.js
@@ -74,9 +74,9 @@ function onFilterInputChange(event) {
   filterTerm = event.target.value.toLowerCase();
 
   let numberOfShownHobbies = 0;
-  for (let hobbyItem of elems.optionsListItems) {
-    hobbyItem.hidden = !hobbyItem.innerText.toLowerCase().includes(filterTerm);
-    if (!hobbyItem.hidden) numberOfShownHobbies += 1;
+  for (let optionItem of elems.optionsListItems) {
+    optionItem.hidden = !optionItem.innerText.toLowerCase().includes(filterTerm);
+    if (!optionItem.hidden) numberOfShownHobbies += 1;
   }
 
   elems.availableOptionsCounter.innerText = `${numberOfShownHobbies} option${
@@ -166,10 +166,10 @@ function onCheckboxChange(event) {
     item.querySelector("label").innerText.trim()
   );
 
-  elems.optionsLegend.innerHTML = `Available hobbies (${checkedItems.length} selected)`;
+  elems.optionsLegend.innerHTML = `Available options (${checkedItems.length} selected)`;
   elems.unselectAllButtonText.innerHTML = composeFilteringButtonText(checkedItemTexts);
   updateSelectedList(checkedItemTexts);
-  elems.selectedOptionsLegend.innerText = `Selected hobbies (${checkedItemTexts.length} in total)`;
+  elems.selectedOptionsLegend.innerText = `Selected options (${checkedItemTexts.length} in total)`;
   elems.selectedOptionsCounter.innerText = `${checkedItems.length} selected.`;
 
   if (checkedItems.length === 0)
@@ -249,10 +249,10 @@ function onSelectedButtonClick(event) {
 
   if (button?.classList.contains("widget--selected-options-button")) {
     const optionText = button.innerText.trim().toLowerCase();
-    const hobbyItem = Array.from(document.querySelectorAll(".widget--options-list-item")).find(
+    const optionItem = Array.from(document.querySelectorAll(".widget--options-list-item")).find(
       (item) => item.querySelector("input").value === optionText
     );
-    hobbyItem.querySelector("input").checked = false;
+    optionItem.querySelector("input").checked = false;
 
     const selectedButtons = Array.from(
       document.querySelectorAll(".widget--selected-options-button")

--- a/scripts.js
+++ b/scripts.js
@@ -22,8 +22,8 @@ elems.optionsLegend = document.querySelector(
 elems.optionsListItems = document.querySelectorAll(".widget--options-list-item");
 elems.optionsListInputs = document.querySelectorAll(".widget--options-list-item input");
 elems.selectedOptionsContainer = document.querySelector(".widget--selected-options-container");
+elems.selectedOptionsLegend = document.querySelector(".widget--selected-options-legend");
 elems.selectedList = document.querySelector(".selected__list");
-elems.selectedLegend = document.querySelector(".selected__legend");
 elems.eventLogger = document.querySelector(".event-logger");
 
 elems.arrowSelectableElems = [elems.filterField, ...elems.optionsListItems];
@@ -169,7 +169,7 @@ function onCheckboxChange(event) {
   elems.optionsLegend.innerHTML = `Available hobbies (${checkedItems.length} selected)`;
   elems.unselectAllButtonText.innerHTML = composeFilteringButtonText(checkedItemTexts);
   updateSelectedList(checkedItemTexts);
-  elems.selectedLegend.innerText = `Selected hobbies (${checkedItemTexts.length} in total)`;
+  elems.selectedOptionsLegend.innerText = `Selected hobbies (${checkedItemTexts.length} in total)`;
   elems.selectedOptionsCounter.innerText = `${checkedItems.length} selected.`;
 
   if (checkedItems.length === 0)

--- a/scripts.js
+++ b/scripts.js
@@ -13,14 +13,14 @@ elems.selectedOptionsCounter = document.querySelector(
   ".widget--selected-options-counter"
 );
 elems.unselectAllButton = document.querySelector(".widget--unselect-all-button");
-elems.unselectAllbuttonText = document.querySelector(".widget--unselect-all-button-text");
+elems.unselectAllButtonText = document.querySelector(".widget--unselect-all-button-text");
+elems.toggleOptionsbutton = document.querySelector(".widget--toggle-options-button");
 elems.options = document.querySelector(".options");
 elems.hobbyItems = document.querySelectorAll(".hobby-item");
 elems.availableHobbiesLegend = document.querySelector(
   ".available-hobbies__legend"
 );
 elems.hobbyItemInputs = document.querySelectorAll(".hobby-item input");
-elems.filterCloseOptions = document.querySelector(".filter__close-options");
 elems.selected = document.querySelector(".selected");
 elems.selectedList = document.querySelector(".selected__list");
 elems.selectedLegend = document.querySelector(".selected__legend");
@@ -51,7 +51,7 @@ const events = {
   optionUnselected: new CustomEvent("option-unselected"),
 };
 
-elems.filterCloseOptions.addEventListener("click", onFilterCloseOptionsClicked);
+elems.toggleOptionsbutton.addEventListener("click", onFilterCloseOptionsClicked);
 
 function onFilterCloseOptionsClicked() {
   isOptionsOpen() ? closeOptions() : openOptions();
@@ -167,7 +167,7 @@ function onCheckboxChange(event) {
   );
 
   elems.availableHobbiesLegend.innerHTML = `Available hobbies (${checkedItems.length} selected)`;
-  elems.unselectAllbuttonText.innerHTML = composeFilteringButtonText(checkedItemTexts);
+  elems.unselectAllButtonText.innerHTML = composeFilteringButtonText(checkedItemTexts);
   updateSelectedList(checkedItemTexts);
   elems.selectedLegend.innerText = `Selected hobbies (${checkedItemTexts.length} in total)`;
   elems.selectedOptionsCounter.innerText = `${checkedItems.length} selected.`;

--- a/scripts.js
+++ b/scripts.js
@@ -4,7 +4,7 @@ const elems = {};
 
 elems.widgetContainer = document.querySelector(".widget--container");
 elems.filterAndOptionsContainer = document.querySelector(".widget--filter-and-options-container");
-elems.filter = document.querySelector(".filter");
+elems.filterContainer = document.querySelector(".widget--filter-container");
 elems.options = document.querySelector(".options");
 elems.hobbyItems = document.querySelectorAll(".hobby-item");
 elems.availableHobbiesLegend = document.querySelector(
@@ -58,7 +58,7 @@ function onFilterCloseOptionsClicked() {
   elems.filterField.select();
 }
 
-for (let elem of [elems.filter, elems.options]) {
+for (let elem of [elems.filterContainer, elems.options]) {
   elem.addEventListener("keyup", function (event) {
     if (event.key === "PageDown" || event.key === "PageUp") {
       const shownElems = [...elems.hobbyItems].filter((elem) => !elem.hidden);

--- a/scripts.js
+++ b/scripts.js
@@ -143,21 +143,21 @@ function modulo(a, n) {
 }
 
 for (let i = 0; i < elems.optionsListInputs.length; i++) {
-  const checkboxInput = elems.optionsListInputs[i];
+  const optionInput = elems.optionsListInputs[i];
 
-  checkboxInput.addEventListener("input", onCheckboxChange);
-  checkboxInput.addEventListener("focus", () => {
+  optionInput.addEventListener("input", onOptionChange);
+  optionInput.addEventListener("focus", () => {
     lastSelected = i + 1;
   });
-  checkboxInput.addEventListener("keyup", (event) => {
+  optionInput.addEventListener("keyup", (event) => {
     if (event.key === "Enter") {
-      const isChecked = checkboxInput.checked;
-      checkboxInput.checked = !isChecked;
+      const isChecked = optionInput.checked;
+      optionInput.checked = !isChecked;
     }
   });
 }
 
-function onCheckboxChange(event) {
+function onOptionChange(event) {
   const checkedItems = Array.from(elems.optionsListItems).filter(
     (elem) => elem.querySelector("input").checked
   );
@@ -185,8 +185,8 @@ function onCheckboxChange(event) {
   }
 }
 
-function composeFilteringButtonText(checkboxLabels) {
-  const numberOfOptions = checkboxLabels.length;
+function composeFilteringButtonText(optionLabels) {
+  const numberOfOptions = optionLabels.length;
 
   return `${numberOfOptions} ${
     numberOfOptions === 0
@@ -210,18 +210,18 @@ function updateSelectedList(checkedItemTexts) {
   elems.selectedOptionsCounter.hidden = checkedItemTexts.length === 0;
 }
 
-elems.optionsListInputs.forEach((checkbox) =>
-  checkbox.addEventListener("keyup", onCheckboxKeyup)
+elems.optionsListInputs.forEach((option) =>
+  option.addEventListener("keyup", onOptionKeyup)
 );
 
-function onCheckboxKeyup(event) {
+function onOptionKeyup(event) {
   if (event.key === "Escape") {
     elems.unselectAllButton.focus();
     closeOptions();
   }
 }
 
-elems.unselectAllButton.addEventListener("click", resetCheckboxes);
+elems.unselectAllButton.addEventListener("click", resetOptiones);
 
 elems.unselectAllButton.addEventListener("keyup", onFilterButtonKeyup);
 
@@ -229,11 +229,11 @@ function onFilterButtonKeyup(event) {
   if (event.key === "Escape") elems.filterInput.select();
 }
 
-function resetCheckboxes() {
-  for (let checkbox of elems.optionsListInputs) {
-    checkbox.checked = false;
+function resetOptiones() {
+  for (let option of elems.optionsListInputs) {
+    option.checked = false;
   }
-  onCheckboxChange({ target: { checked: false, value: "all checkboxes" } });
+  onOptionChange({ target: { checked: false, value: "all optiones" } });
   elems.filterInput.select();
 }
 
@@ -280,7 +280,7 @@ function onSelectedButtonClick(event) {
       } else elems.filterInput.select();
     }
 
-    onCheckboxChange({ target: { checked: false, value: optionText } });
+    onOptionChange({ target: { checked: false, value: optionText } });
   } else {
     return true;
   }
@@ -339,14 +339,14 @@ function isTargetElementInDirectTree({ event, targetElement }) {
 
 elems.widgetContainer.addEventListener(`option-selected`, (event) => {
   elems.eventLogger.innerText =
-    event.detail === `all checkboxes`
-      ? `Event: All checkboxes were unselected`
+    event.detail === `all optiones`
+      ? `Event: All optiones were unselected`
       : `Event: Option ${event.detail} was ${event.type.split("-")[1]}`;
 });
 
 elems.widgetContainer.addEventListener(`option-unselected`, (event) => {
   elems.eventLogger.innerText =
-    event.detail === `all checkboxes`
-      ? `Event: All checkboxes were unselected`
+    event.detail === `all optiones`
+      ? `Event: All optiones were unselected`
       : `Event: Option ${event.detail} was ${event.type.split("-")[1]}`;
 });

--- a/scripts.js
+++ b/scripts.js
@@ -2,7 +2,7 @@
 
 const elems = {};
 
-elems.multi = document.querySelector(".multi");
+elems.widget = document.querySelector(".widget");
 elems.filterAndOptions = document.querySelector(".filter-and-options");
 elems.filter = document.querySelector(".filter");
 elems.options = document.querySelector(".options");
@@ -91,7 +91,7 @@ function onFilterFieldChangeOnce() {
   elems.filterField.removeEventListener("input", onFilterFieldChangeOnce);
 }
 
-elems.multi.addEventListener("keyup", onKeyup);
+elems.widget.addEventListener("keyup", onKeyup);
 
 function onKeyup(event) {
   if (event.key === "ArrowDown" || event.key === "ArrowUp") {
@@ -177,7 +177,7 @@ function onCheckboxChange(event) {
   else elems.filterResetOptions.removeAttribute("hidden");
 
   if (event?.target) {
-    elems.multi.dispatchEvent(
+    elems.widget.dispatchEvent(
       new CustomEvent(`option-${event.target.checked ? "" : "un"}selected`, {
         detail: event.target.value,
       })
@@ -337,14 +337,14 @@ function isTargetElementInDirectTree({ event, targetElement }) {
   }
 }
 
-elems.multi.addEventListener(`option-selected`, (event) => {
+elems.widget.addEventListener(`option-selected`, (event) => {
   elems.eventLogger.innerText =
     event.detail === `all checkboxes`
       ? `Event: All checkboxes were unselected`
       : `Event: Option ${event.detail} was ${event.type.split("-")[1]}`;
 });
 
-elems.multi.addEventListener(`option-unselected`, (event) => {
+elems.widget.addEventListener(`option-unselected`, (event) => {
   elems.eventLogger.innerText =
     event.detail === `all checkboxes`
       ? `Event: All checkboxes were unselected`

--- a/scripts.js
+++ b/scripts.js
@@ -168,8 +168,8 @@ function onOptionChange(event) {
   );
 
   elems.optionsLegend.innerHTML = `Available options (${checkedItems.length} selected)`;
-  elems.unselectAllButtonText.innerHTML = composeFilteringButtonText(checkedItemTexts);
-  updateSelectedList(checkedItemTexts);
+  elems.unselectAllButtonText.innerHTML = composeUnselectAllButtonText(checkedItemTexts);
+  updateSelectedOptionsList(checkedItemTexts);
   elems.selectedOptionsLegend.innerText = `Selected options (${checkedItemTexts.length} in total)`;
   elems.selectedOptionsCounter.innerText = `${checkedItems.length} selected.`;
 
@@ -186,7 +186,7 @@ function onOptionChange(event) {
   }
 }
 
-function composeFilteringButtonText(optionLabels) {
+function composeUnselectAllButtonText(optionLabels) {
   const numberOfOptions = optionLabels.length;
 
   return `${numberOfOptions} ${
@@ -198,7 +198,7 @@ function composeFilteringButtonText(optionLabels) {
   }`;
 }
 
-function updateSelectedList(checkedItemTexts) {
+function updateSelectedOptionsList(checkedItemTexts) {
   const allEntries = checkedItemTexts
     .map(
       (

--- a/scripts.js
+++ b/scripts.js
@@ -19,14 +19,14 @@ elems.optionsContainer = document.querySelector(".widget--options-container");
 elems.optionsLegend = document.querySelector(
   ".widget--options-legend"
 );
-elems.hobbyItems = document.querySelectorAll(".hobby-item");
-elems.hobbyItemInputs = document.querySelectorAll(".hobby-item input");
+elems.optionsListItems = document.querySelectorAll(".widget--options-list-item");
+elems.optionsListInputs = document.querySelectorAll(".widget--options-list-item input");
 elems.selected = document.querySelector(".selected");
 elems.selectedList = document.querySelector(".selected__list");
 elems.selectedLegend = document.querySelector(".selected__legend");
 elems.eventLogger = document.querySelector(".event-logger");
 
-elems.arrowSelectableElems = [elems.filterField, ...elems.hobbyItems];
+elems.arrowSelectableElems = [elems.filterField, ...elems.optionsListItems];
 elems.filterField.addEventListener("input", onFilterFieldChange);
 elems.filterField.addEventListener("input", onFilterFieldChangeOnce);
 elems.filterField.addEventListener("keyup", onFilterFieldKeyup);
@@ -61,7 +61,7 @@ function onFilterCloseOptionsClicked() {
 for (let elem of [elems.filterContainer, elems.optionsContainer]) {
   elem.addEventListener("keyup", function (event) {
     if (event.key === "PageDown" || event.key === "PageUp") {
-      const shownElems = [...elems.hobbyItems].filter((elem) => !elem.hidden);
+      const shownElems = [...elems.optionsListItems].filter((elem) => !elem.hidden);
       const elemToFocus = shownElems
         .at(event.key === "PageDown" ? -1 : 0)
         .querySelector("input");
@@ -74,7 +74,7 @@ function onFilterFieldChange(event) {
   filterTerm = event.target.value.toLowerCase();
 
   let numberOfShownHobbies = 0;
-  for (let hobbyItem of elems.hobbyItems) {
+  for (let hobbyItem of elems.optionsListItems) {
     hobbyItem.hidden = !hobbyItem.innerText.toLowerCase().includes(filterTerm);
     if (!hobbyItem.hidden) numberOfShownHobbies += 1;
   }
@@ -142,8 +142,8 @@ function modulo(a, n) {
   return ((a % n) + n) % n;
 }
 
-for (let i = 0; i < elems.hobbyItemInputs.length; i++) {
-  const checkboxInput = elems.hobbyItemInputs[i];
+for (let i = 0; i < elems.optionsListInputs.length; i++) {
+  const checkboxInput = elems.optionsListInputs[i];
 
   checkboxInput.addEventListener("input", onCheckboxChange);
   checkboxInput.addEventListener("focus", () => {
@@ -158,7 +158,7 @@ for (let i = 0; i < elems.hobbyItemInputs.length; i++) {
 }
 
 function onCheckboxChange(event) {
-  const checkedItems = Array.from(elems.hobbyItems).filter(
+  const checkedItems = Array.from(elems.optionsListItems).filter(
     (elem) => elem.querySelector("input").checked
   );
 
@@ -210,7 +210,7 @@ function updateSelectedList(checkedItemTexts) {
   elems.selected.hidden = checkedItemTexts.length === 0;
 }
 
-elems.hobbyItemInputs.forEach((checkbox) =>
+elems.optionsListInputs.forEach((checkbox) =>
   checkbox.addEventListener("keyup", onCheckboxKeyup)
 );
 
@@ -230,7 +230,7 @@ function onFilterButtonKeyup(event) {
 }
 
 function resetCheckboxes() {
-  for (let checkbox of elems.hobbyItemInputs) {
+  for (let checkbox of elems.optionsListInputs) {
     checkbox.checked = false;
   }
   onCheckboxChange({ target: { checked: false, value: "all checkboxes" } });
@@ -249,7 +249,7 @@ function onSelectedButtonClick(event) {
 
   if (button?.classList.contains("selected__button")) {
     const optionText = button.innerText.trim().toLowerCase();
-    const hobbyItem = Array.from(document.querySelectorAll(".hobby-item")).find(
+    const hobbyItem = Array.from(document.querySelectorAll(".widget--options-list-item")).find(
       (item) => item.querySelector("input").value === optionText
     );
     hobbyItem.querySelector("input").checked = false;

--- a/scripts.js
+++ b/scripts.js
@@ -15,7 +15,7 @@ elems.selectedOptionsCounter = document.querySelector(
 elems.unselectAllButton = document.querySelector(".widget--unselect-all-button");
 elems.unselectAllButtonText = document.querySelector(".widget--unselect-all-button-text");
 elems.toggleOptionsbutton = document.querySelector(".widget--toggle-options-button");
-elems.options = document.querySelector(".options");
+elems.optionsContainer = document.querySelector(".widget--options-container");
 elems.hobbyItems = document.querySelectorAll(".hobby-item");
 elems.availableHobbiesLegend = document.querySelector(
   ".available-hobbies__legend"
@@ -58,7 +58,7 @@ function onFilterCloseOptionsClicked() {
   elems.filterField.select();
 }
 
-for (let elem of [elems.filterContainer, elems.options]) {
+for (let elem of [elems.filterContainer, elems.optionsContainer]) {
   elem.addEventListener("keyup", function (event) {
     if (event.key === "PageDown" || event.key === "PageUp") {
       const shownElems = [...elems.hobbyItems].filter((elem) => !elem.hidden);
@@ -287,19 +287,19 @@ function onSelectedButtonClick(event) {
 }
 
 function openOptions() {
-  elems.options.removeAttribute("hidden");
+  elems.optionsContainer.removeAttribute("hidden");
   elems.filterField.setAttribute("aria-expanded", true);
   elems.filterAndOptionsContainer.classList.add("open");
 }
 
 function closeOptions() {
-  elems.options.setAttribute("hidden", "");
+  elems.optionsContainer.setAttribute("hidden", "");
   elems.filterField.setAttribute("aria-expanded", false);
   elems.filterAndOptionsContainer.classList.remove("open");
 }
 
 function isOptionsOpen() {
-  return elems.options.getAttribute("hidden") === null;
+  return elems.optionsContainer.getAttribute("hidden") === null;
 }
 
 document.body.addEventListener("click", (event) => {

--- a/scripts.js
+++ b/scripts.js
@@ -2,8 +2,8 @@
 
 const elems = {};
 
-elems.widgetContainer = document.querySelector(".widget-container");
-elems.filterAndOptionsContainer = document.querySelector(".widget--filter-and-options");
+elems.widgetContainer = document.querySelector(".widget--container");
+elems.filterAndOptionsContainer = document.querySelector(".widget--filter-and-options-container");
 elems.filter = document.querySelector(".filter");
 elems.options = document.querySelector(".options");
 elems.hobbyItems = document.querySelectorAll(".hobby-item");

--- a/scripts.js
+++ b/scripts.js
@@ -26,7 +26,7 @@ elems.selectedOptionsLegend = document.querySelector(".widget--selected-options-
 elems.selectedOptionsList = document.querySelector(".widget--selected-options-list");
 elems.eventLogger = document.querySelector(".event-logger");
 
-elems.arrowSelectableElems = [elems.filterInput, ...elems.optionsListItems];
+elems.arrowSelectableElements = [elems.filterInput, ...elems.optionsListItems];
 elems.filterInput.addEventListener("input", onFilterInputChange);
 elems.filterInput.addEventListener("input", onFilterInputChangeOnce);
 elems.filterInput.addEventListener("keyup", onFilterInputKeyup);
@@ -43,10 +43,10 @@ function onFilterInputKeyup(event) {
 
 let filterTerm = "";
 let FilterInputHasFocus;
-let lastSelected = 0;
-let numberOfElems = elems.arrowSelectableElems.length;
+let lastArrowSelectedElement = 0; // TODO: I think we don't really need to manage such a counter, let's just decide on the go which element to select next (which depends on where the focus currently is)!
 const textInputRegexp = /^(([a-zA-Z])|(Backspace)|(Delete))$/;
 const events = {
+  // TODO: Do we need to also prefix them, ie. with `widget--`?
   optionSelected: new CustomEvent("option-selected"),
   optionUnselected: new CustomEvent("option-unselected"),
 };
@@ -97,9 +97,10 @@ function onKeyup(event) {
   if (event.key === "ArrowDown" || event.key === "ArrowUp") {
     if (isOptionsOpen()) {
       const direction = event.key === "ArrowDown" ? 1 : -1;
-      for (let i = 0; i < elems.arrowSelectableElems.length; i++) {
-        let j = modulo(direction * (i + 1) + lastSelected, numberOfElems);
-        let currentElem = elems.arrowSelectableElems[j];
+      for (let i = 0; i < elems.arrowSelectableElements.length; i++) {
+        let numberOfArrowSelectableElements = elems.arrowSelectableElements.length;
+        let j = modulo(direction * (i + 1) + lastArrowSelectedElement, numberOfArrowSelectableElements);
+        let currentElem = elems.arrowSelectableElements[j];
         if (!currentElem.hidden) {
           if (currentElem === elems.filterInput) {
             currentElem.select();
@@ -135,7 +136,7 @@ function onKeyup(event) {
 }
 
 elems.filterInput.addEventListener("focus", () => {
-  lastSelected = 0;
+  lastArrowSelectedElement = 0;
 });
 
 function modulo(a, n) {
@@ -147,7 +148,7 @@ for (let i = 0; i < elems.optionsListInputs.length; i++) {
 
   optionInput.addEventListener("input", onOptionChange);
   optionInput.addEventListener("focus", () => {
-    lastSelected = i + 1;
+    lastArrowSelectedElement = i + 1;
   });
   optionInput.addEventListener("keyup", (event) => {
     if (event.key === "Enter") {

--- a/scripts.js
+++ b/scripts.js
@@ -26,7 +26,7 @@ elems.selectedOptionsLegend = document.querySelector(".widget--selected-options-
 elems.selectedOptionsList = document.querySelector(".widget--selected-options-list");
 elems.eventLogger = document.querySelector(".event-logger");
 
-elems.arrowSelectableElements = [elems.filterInput, ...elems.optionsListItems];
+elems.arrowSelectableElems = [elems.filterInput, ...elems.optionsListItems];
 elems.filterInput.addEventListener("input", onFilterInputChange);
 elems.filterInput.addEventListener("input", onFilterInputChangeOnce);
 elems.filterInput.addEventListener("keyup", onFilterInputKeyup);
@@ -43,7 +43,7 @@ function onFilterInputKeyup(event) {
 
 let filterTerm = "";
 let FilterInputHasFocus;
-let lastArrowSelectedElement = 0; // TODO: I think we don't really need to manage such a counter, let's just decide on the go which element to select next (which depends on where the focus currently is)!
+let lastArrowSelectedElem = 0; // TODO: I think we don't really need to manage such a counter, let's just decide on the go which element to select next (which depends on where the focus currently is)!
 const textInputRegexp = /^(([a-zA-Z])|(Backspace)|(Delete))$/;
 const events = {
   // TODO: Do we need to also prefix them, ie. with `widget--`?
@@ -97,10 +97,10 @@ function onKeyup(event) {
   if (event.key === "ArrowDown" || event.key === "ArrowUp") {
     if (isOptionsOpen()) {
       const direction = event.key === "ArrowDown" ? 1 : -1;
-      for (let i = 0; i < elems.arrowSelectableElements.length; i++) {
-        let numberOfArrowSelectableElements = elems.arrowSelectableElements.length;
-        let j = modulo(direction * (i + 1) + lastArrowSelectedElement, numberOfArrowSelectableElements);
-        let currentElem = elems.arrowSelectableElements[j];
+      for (let i = 0; i < elems.arrowSelectableElems.length; i++) {
+        let numberOfArrowSelectableElems = elems.arrowSelectableElems.length;
+        let j = modulo(direction * (i + 1) + lastArrowSelectedElem, numberOfArrowSelectableElems);
+        let currentElem = elems.arrowSelectableElems[j];
         if (!currentElem.hidden) {
           if (currentElem === elems.filterInput) {
             currentElem.select();
@@ -136,7 +136,7 @@ function onKeyup(event) {
 }
 
 elems.filterInput.addEventListener("focus", () => {
-  lastArrowSelectedElement = 0;
+  lastArrowSelectedElem = 0;
 });
 
 function modulo(a, n) {
@@ -148,7 +148,7 @@ for (let i = 0; i < elems.optionsListInputs.length; i++) {
 
   optionInput.addEventListener("input", onOptionChange);
   optionInput.addEventListener("focus", () => {
-    lastArrowSelectedElement = i + 1;
+    lastArrowSelectedElem = i + 1;
   });
   optionInput.addEventListener("keyup", (event) => {
     if (event.key === "Enter") {
@@ -305,9 +305,9 @@ function isOptionsOpen() {
 
 document.body.addEventListener("click", (event) => {
   if (
-    !isTargetElementInDirectTree({
+    !isTargetElemInDirectTree({
       event,
-      targetElement: elems.filterAndOptionsContainer,
+      targetElem: elems.filterAndOptionsContainer,
     })
   ) {
     closeOptions();
@@ -317,19 +317,19 @@ document.body.addEventListener("click", (event) => {
 document.body.addEventListener("keyup", (event) => {
   if (
     event.key === "Tab" &&
-    !isTargetElementInDirectTree({
+    !isTargetElemInDirectTree({
       event,
-      targetElement: elems.filterAndOptionsContainer,
+      targetElem: elems.filterAndOptionsContainer,
     })
   ) {
     closeOptions();
   }
 });
 
-function isTargetElementInDirectTree({ event, targetElement }) {
+function isTargetElemInDirectTree({ event, targetElem }) {
   let elem = event.target;
   while (elem) {
-    if (elem !== targetElement) {
+    if (elem !== targetElem) {
       if (elem.parentNode) elem = elem.parentNode;
       else {
         return false;

--- a/scripts.js
+++ b/scripts.js
@@ -12,13 +12,13 @@ elems.availableOptionsCounter = document.querySelector(
 elems.selectedOptionsCounter = document.querySelector(
   ".widget--selected-options-counter"
 );
+elems.unselectAllButton = document.querySelector(".widget--unselect-all-button");
 elems.options = document.querySelector(".options");
 elems.hobbyItems = document.querySelectorAll(".hobby-item");
 elems.availableHobbiesLegend = document.querySelector(
   ".available-hobbies__legend"
 );
 elems.hobbyItemInputs = document.querySelectorAll(".hobby-item input");
-elems.filterResetOptions = document.querySelector(".filter__reset-options");
 elems.filterText = document.querySelector(".filter__text");
 elems.filterCloseOptions = document.querySelector(".filter__close-options");
 elems.selected = document.querySelector(".selected");
@@ -173,8 +173,8 @@ function onCheckboxChange(event) {
   elems.selectedOptionsCounter.innerText = `${checkedItems.length} selected.`;
 
   if (checkedItems.length === 0)
-    elems.filterResetOptions.setAttribute("hidden", "");
-  else elems.filterResetOptions.removeAttribute("hidden");
+    elems.unselectAllButton.setAttribute("hidden", "");
+  else elems.unselectAllButton.removeAttribute("hidden");
 
   if (event?.target) {
     elems.widgetContainer.dispatchEvent(
@@ -216,14 +216,14 @@ elems.hobbyItemInputs.forEach((checkbox) =>
 
 function onCheckboxKeyup(event) {
   if (event.key === "Escape") {
-    elems.filterResetOptions.focus();
+    elems.unselectAllButton.focus();
     closeOptions();
   }
 }
 
-elems.filterResetOptions.addEventListener("click", resetCheckboxes);
+elems.unselectAllButton.addEventListener("click", resetCheckboxes);
 
-elems.filterResetOptions.addEventListener("keyup", onFilterButtonKeyup);
+elems.unselectAllButton.addEventListener("keyup", onFilterButtonKeyup);
 
 function onFilterButtonKeyup(event) {
   if (event.key === "Escape") elems.filterField.select();

--- a/scripts.js
+++ b/scripts.js
@@ -3,7 +3,7 @@
 const elems = {};
 
 elems.widget = document.querySelector(".widget");
-elems.filterAndOptions = document.querySelector(".filter-and-options");
+elems.filterAndOptionsContainer = document.querySelector(".widget--filter-and-options");
 elems.filter = document.querySelector(".filter");
 elems.options = document.querySelector(".options");
 elems.hobbyItems = document.querySelectorAll(".hobby-item");
@@ -289,13 +289,13 @@ function onSelectedButtonClick(event) {
 function openOptions() {
   elems.options.removeAttribute("hidden");
   elems.filterField.setAttribute("aria-expanded", true);
-  elems.filterAndOptions.classList.add("open");
+  elems.filterAndOptionsContainer.classList.add("open");
 }
 
 function closeOptions() {
   elems.options.setAttribute("hidden", "");
   elems.filterField.setAttribute("aria-expanded", false);
-  elems.filterAndOptions.classList.remove("open");
+  elems.filterAndOptionsContainer.classList.remove("open");
 }
 
 function isOptionsOpen() {
@@ -306,7 +306,7 @@ document.body.addEventListener("click", (event) => {
   if (
     !isTargetElementInDirectTree({
       event,
-      targetElement: elems.filterAndOptions,
+      targetElement: elems.filterAndOptionsContainer,
     })
   ) {
     closeOptions();
@@ -318,7 +318,7 @@ document.body.addEventListener("keyup", (event) => {
     event.key === "Tab" &&
     !isTargetElementInDirectTree({
       event,
-      targetElement: elems.filterAndOptions,
+      targetElement: elems.filterAndOptionsContainer,
     })
   ) {
     closeOptions();

--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,7 @@ form {
 
 .widget--filter-field:focus,
 .widget--filter-and-options-container:focus-within .widget--filter-field,
-.filter__close-options:focus {
+.widget--toggle-options-button:focus {
   outline: 1px solid red;
   position: relative;
   z-index: 1;
@@ -50,11 +50,11 @@ form {
 }
 
 .widget--unselect-all-button:hover,
-.filter__close-options {
+.widget--toggle-options-button {
   cursor: pointer;
 }
 
-.filter__close-options {
+.widget--toggle-options-button {
   height: 24px;
   border: 1px solid #000;
   margin-left: -1px;
@@ -62,11 +62,11 @@ form {
   border-top-right-radius: 6px;
 }
 
-.widget--filter-and-options-container:not(.open) .filter__close-options {
+.widget--filter-and-options-container:not(.open) .widget--toggle-options-button {
   border-bottom-right-radius: 6px;
 }
 
-.widget--filter-and-options-container:not(.open) .filter__close-options img {
+.widget--filter-and-options-container:not(.open) .widget--toggle-options-button img {
   transform: rotate(180deg);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -18,7 +18,7 @@ form {
   padding: 2px 4px;
 }
 
-.filter-and-options:not(.open) .filter__field {
+.widget--filter-and-options:not(.open) .filter__field {
   border-bottom-left-radius: 6px;
 }
 
@@ -27,7 +27,7 @@ form {
 }
 
 .filter__field:focus,
-.filter-and-options:focus-within .filter__field,
+.widget--filter-and-options:focus-within .filter__field,
 .filter__close-options:focus {
   outline: 1px solid red;
   position: relative;
@@ -62,11 +62,11 @@ form {
   border-top-right-radius: 6px;
 }
 
-.filter-and-options:not(.open) .filter__close-options {
+.widget--filter-and-options:not(.open) .filter__close-options {
   border-bottom-right-radius: 6px;
 }
 
-.filter-and-options:not(.open) .filter__close-options img {
+.widget--filter-and-options:not(.open) .filter__close-options img {
   transform: rotate(180deg);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -34,7 +34,7 @@ form {
   z-index: 1;
 }
 
-.filter__reset-options {
+.widget--unselect-all-button {
   position: absolute;
   border: 0;
   background-color: transparent;
@@ -45,11 +45,11 @@ form {
   border-radius: 100%;
 }
 
-.filter__reset-options:focus {
+.widget--unselect-all-button:focus {
   outline: 1px solid red;
 }
 
-.filter__reset-options:hover,
+.widget--unselect-all-button:hover,
 .filter__close-options {
   cursor: pointer;
 }

--- a/styles.css
+++ b/styles.css
@@ -70,7 +70,7 @@ form {
   transform: rotate(180deg);
 }
 
-.selected {
+.widget--selected-options-container {
   margin-top: 1em;
   border: 0;
   padding: 0;

--- a/styles.css
+++ b/styles.css
@@ -88,22 +88,22 @@ form {
   margin-right: 0.5em;
 }
 
-.selected__button {
+.widget--selected-options-button {
   border-radius: 6px;
   border: 1px solid #000;
   padding: 2px 4px;
 }
 
-.selected__button img {
+.widget--selected-options-button img {
   vertical-align: bottom;
 }
 
-.selected__button:hover {
+.widget--selected-options-button:hover {
   cursor: pointer;
 }
   border-radius: 6px;
 
-.selected__button img {
+.widget--selected-options-button img {
   vertical-align: bottom;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -107,7 +107,7 @@ form {
   vertical-align: bottom;
 }
 
-.options {
+.widget--options-container {
   margin: 0;
   border: 1px solid #000;
   padding: 0;

--- a/styles.css
+++ b/styles.css
@@ -127,13 +127,13 @@ form {
   /* background-color: rgb(179, 255, 129); */
 }
 
-.options__list {
+.widget--options-list {
   color: transparent; /* To hide the bullet point numbers (1., 2., etc.) visually, but let screen readers announce them. */
   padding: 0;
   margin: 0;
 }
 
-.options__list label {
+.widget--options-list label {
   color: #000;
   padding: 2 4px;
   display: inline-block;
@@ -142,23 +142,23 @@ form {
   border-left: 4px solid transparent; /* For high contrast mode */
 }
 
-.options__list input:hover {
+.widget--options-list input:hover {
   cursor: pointer;
 }
 
-.options__list label:focus-within,
-.options__list label:hover {
+.widget--options-list label:focus-within,
+.widget--options-list label:hover {
   background-color: rgb(255, 167, 167);
   cursor: pointer;
   border-left-color: #000;
 }
 
-.options__list input:checked + span {
+.widget--options-list input:checked + span {
   font-weight: bold;
 }
 
 /* Seems to break checked / not checked announcements in Chrome (for both NVDA and JAWS) => an alternative could be to simply toggle the display of a <span> with an SVG as background. */
-.options__list input:checked + span .check {
+.widget--options-list input:checked + span .check {
   content: " ";
   display: inline-block;
   margin-left: 0.25em;

--- a/styles.css
+++ b/styles.css
@@ -2,15 +2,15 @@ form {
   margin: 0;
 }
 
-.filter__label {
+.widget--filter-label {
   width: 100px;
 }
 
-.filter__label::after {
+.widget--filter-label::after {
   content: ":";
 }
 
-.filter__field {
+.widget--filter-field {
   width: 160px;
   border: 1px solid #000;
   height: 24px;
@@ -18,16 +18,16 @@ form {
   padding: 2px 4px;
 }
 
-.widget--filter-and-options-container:not(.open) .filter__field {
+.widget--filter-and-options-container:not(.open) .widget--filter-field {
   border-bottom-left-radius: 6px;
 }
 
-.filter__field:focus {
+.widget--filter-field:focus {
   background-color: rgb(255, 235, 235);
 }
 
-.filter__field:focus,
-.widget--filter-and-options-container:focus-within .filter__field,
+.widget--filter-field:focus,
+.widget--filter-and-options-container:focus-within .widget--filter-field,
 .filter__close-options:focus {
   outline: 1px solid red;
   position: relative;

--- a/styles.css
+++ b/styles.css
@@ -168,7 +168,7 @@ form {
   background: url(check.svg);
 }
 
-.available-hobbies__legend {
+.widget--options-legend {
   background-color: #000;
   color: #fff;
   border: 1px solid #000;

--- a/styles.css
+++ b/styles.css
@@ -108,7 +108,7 @@ form {
 }
 
 .options {
-  margin-left: 100px;
+  margin: 0;
   border: 1px solid #000;
   padding: 0;
   position: absolute;

--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,7 @@ form {
   content: ":";
 }
 
-.widget--filter-field {
+.widget--filter-input {
   width: 160px;
   border: 1px solid #000;
   height: 24px;
@@ -18,16 +18,16 @@ form {
   padding: 2px 4px;
 }
 
-.widget--filter-and-options-container:not(.open) .widget--filter-field {
+.widget--filter-and-options-container:not(.open) .widget--filter-input {
   border-bottom-left-radius: 6px;
 }
 
-.widget--filter-field:focus {
+.widget--filter-input:focus {
   background-color: rgb(255, 235, 235);
 }
 
-.widget--filter-field:focus,
-.widget--filter-and-options-container:focus-within .widget--filter-field,
+.widget--filter-input:focus,
+.widget--filter-and-options-container:focus-within .widget--filter-input,
 .widget--toggle-options-button:focus {
   outline: 1px solid red;
   position: relative;

--- a/styles.css
+++ b/styles.css
@@ -18,7 +18,7 @@ form {
   padding: 2px 4px;
 }
 
-.widget--filter-and-options:not(.open) .filter__field {
+.widget--filter-and-options-container:not(.open) .filter__field {
   border-bottom-left-radius: 6px;
 }
 
@@ -27,7 +27,7 @@ form {
 }
 
 .filter__field:focus,
-.widget--filter-and-options:focus-within .filter__field,
+.widget--filter-and-options-container:focus-within .filter__field,
 .filter__close-options:focus {
   outline: 1px solid red;
   position: relative;
@@ -62,11 +62,11 @@ form {
   border-top-right-radius: 6px;
 }
 
-.widget--filter-and-options:not(.open) .filter__close-options {
+.widget--filter-and-options-container:not(.open) .filter__close-options {
   border-bottom-right-radius: 6px;
 }
 
-.widget--filter-and-options:not(.open) .filter__close-options img {
+.widget--filter-and-options-container:not(.open) .filter__close-options img {
   transform: rotate(180deg);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -76,14 +76,14 @@ form {
   padding: 0;
 }
 
-.selected__list {
+.widget--selected-options-list {
   margin: 0;
   padding: 0;
   overflow: hidden;
   color: transparent; /* To hide the bullet point numbers (1., 2., etc.) visually, but let screen readers announce them. */
 }
 
-.selected__list li {
+.widget--selected-options-list li {
   float: left; /* TODO: Rather use flexbox here? */
   margin-right: 0.5em;
 }

--- a/styles.css
+++ b/styles.css
@@ -107,7 +107,7 @@ form {
   vertical-align: bottom;
 }
 
-.widget--options-container {
+.widget--available-options-container {
   margin: 0;
   border: 1px solid #000;
   padding: 0;


### PR DESCRIPTION
I decided to stick with the following convention:

- `widget--` as prefix for each class name
- instead of BEM, I simply use a sequence of meaningful descriptive words, ie. `.selected-options-container`, `.selected-options-legend`, `.selected-options-list`, `.selected-options-list-item`, `.selected-options-button`

I also decided to remove any occurrences of "Hobby" (or similar) from the JavaScript and CSS code, and updated some of the JavaScript with more descriptive names.